### PR TITLE
Added check for netstat status field to prevent a false positive that…

### DIFF
--- a/pycloudsqlproxy/__init__.py
+++ b/pycloudsqlproxy/__init__.py
@@ -18,7 +18,7 @@ def connect(instances):
         for line in netstat.stdout:
             txt = line.decode('utf-8')
 
-            if '3306' in txt:
+            if '3306' in txt and 'LISTEN' in txt:
                 els = txt.split()
                 log.info('>> cloud_sql_proxy listening on {}'.format(els[3]))
                 return True


### PR DESCRIPTION
… would identify 3306 as listening

E.g.:
```Proto Recv-Q Send-Q Local Address           Foreign Address         State       User       Inode      PID/Program name    
tcp        0      0 127.0.0.1:3306          127.0.0.1:39490         TIME_WAIT   0          0          -                   
 ```